### PR TITLE
Deeplinking

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -76,6 +76,7 @@ class App extends React.Component {
     walletWeb3: getWeb3(web3Providers.wallet),
     web3: getWeb3(web3Providers.default),
     wrapper: null,
+    appRouteQuery: '',
   }
 
   history = createHistory()
@@ -128,8 +129,18 @@ class App extends React.Component {
     }
   }
 
+  composeAppRouteQuery = parts => {
+    let result = ''
+    for (let part of parts) {
+      result += '/' + part
+    }
+    // Remove first slash so we do not duplicate it over and over
+    return result.substr(1)
+  }
+
   updateLocator = locator => {
     const { locator: prevLocator } = this.state
+    this.setState({ appRouteQuery: this.composeAppRouteQuery(locator.parts) })
 
     if (locator.mode === APP_MODE_START || locator.mode === APP_MODE_SETUP) {
       this.updateDaoBuilder()
@@ -376,6 +387,7 @@ class App extends React.Component {
       walletWeb3,
       web3,
       wrapper,
+      appRouteQuery,
     } = this.state
 
     const { mode, dao } = locator
@@ -452,6 +464,7 @@ class App extends React.Component {
                       walletWeb3={walletWeb3}
                       web3={web3}
                       wrapper={wrapper}
+                      appRouteQuery={appRouteQuery}
                     />
                   </div>
                 </PermissionsProvider>

--- a/src/Wrapper.js
+++ b/src/Wrapper.js
@@ -153,6 +153,7 @@ class Wrapper extends React.PureComponent {
         value.indexOf('#') !== -1 ? value.replace('#', '') : value
       historyPush(
         getAppPath({ dao: locator.dao, instanceId: locator.instanceId }) +
+          '/' +
           sanitizedValue
       )
     }

--- a/src/Wrapper.js
+++ b/src/Wrapper.js
@@ -51,6 +51,7 @@ class Wrapper extends React.PureComponent {
     walletWeb3: PropTypes.object,
     web3: PropTypes.object,
     wrapper: AragonType,
+    appRouteQuery: PropTypes.string,
   }
 
   static defaultProps = {
@@ -61,6 +62,7 @@ class Wrapper extends React.PureComponent {
     walletNetwork: '',
     walletProviderId: '',
     walletWeb3: null,
+    appRouteQuery: '',
   }
 
   state = {
@@ -134,6 +136,8 @@ class Wrapper extends React.PureComponent {
     this.sendDisplayMenuButtonStatus()
   }
   handleAppMessage = ({ data: { name, value } }) => {
+    const { historyPush, locator } = this.props
+
     if (
       // “menuPanel: Boolean” is deprecated but still supported for a while if
       // value is `true`.
@@ -142,6 +146,15 @@ class Wrapper extends React.PureComponent {
       name === 'requestMenu'
     ) {
       this.setState({ menuPanelOpened: value === true })
+    } else if (name === 'hashChange') {
+      // Since aragon uses hashes for routes, we need to avoid other hashes in the url
+      // TODO: Santize value better
+      const sanitizedValue =
+        value.indexOf('#') !== -1 ? value.replace('#', '') : value
+      historyPush(
+        getAppPath({ dao: locator.dao, instanceId: locator.instanceId }) +
+          sanitizedValue
+      )
     }
   }
   handleMenuPanelOpen = () => {
@@ -313,6 +326,7 @@ class Wrapper extends React.PureComponent {
       walletNetwork,
       walletWeb3,
       wrapper,
+      appRouteQuery,
     } = this.props
 
     const appsLoading = appsStatus === APPS_STATUS_LOADING
@@ -387,6 +401,7 @@ class Wrapper extends React.PureComponent {
         ref={this.handleAppIFrameRef}
         onLoad={this.handleAppIFrameLoad}
         onMessage={this.handleAppMessage}
+        appRouteQuery={appRouteQuery}
       />
     ) : (
       <App404 onNavigateBack={this.props.historyBack} />

--- a/src/aragonjs-wrapper.js
+++ b/src/aragonjs-wrapper.js
@@ -485,9 +485,7 @@ const templateParamFilters = {
 
     if (neededSignatures < 1 || neededSignatures > signers.length) {
       throw new Error(
-        `neededSignatures must be between 1 and the total number of signers (${
-          signers.length
-        })`,
+        `neededSignatures must be between 1 and the total number of signers (${signers.length})`,
         neededSignatures
       )
     }


### PR DESCRIPTION
# Deep-linking research progress

## Sending deep links from the Aragon client to the sandboxed app

### When the browser URL changes, the last fragment of it is sent to the iframe, this is by web api design

This happens because the iframe has the `src` param that holds the info, the google maps example at the [mdn iframe docs page](https://developer.mozilla.org/fr/docs/Web/HTML/Element/iframe) uses a similar pattern

- Example

```https://rinkeby.aragon.org/#/test/0x35a89b2a771361c61871a07ad268a29976ebfc36/vote/12```

The client will send the last fragment after the app instance address, and transform by prepending a hash to it, so the app developer can select the most convenient way to handle the path routing 
> `react-router` was used for this research and demo, because is also being used on the `aragon-client`, and it seems the most adopted solution

- So the actual network request will be
```https://ipfs.eth.aragon.network/ipfs/QmTCYzgvrjtV4ETkhM3ZNgrVYNi2roXhNxCRmwsePNqL1B/index.html/#/vote/12```

## Reverse case, sending the route path from the sandboxed app to the parent client

Child iframe needs to change the url of the parent, so a new function using the `postMessage` pattern was added.
It is called `hashChange`  and its task is simple: It will add the desired URL at the end of current app url, to be routed by the client, who always initialises the "routing cycle"

- Example
With the URL:

```https://rinkeby.aragon.org/#/test/0x35a89b2a771361c61871a07ad268a29976ebfc36/```

If the user clicks a link inside the iframe, pointing to `#/home`, the app will run `hashChange` with `postMessage` and parent url will change to: 
```https://rinkeby.aragon.org/#/test/0x35a89b2a771361c61871a07ad268a29976ebfc36/home```

This will also change the iframe src to: 
```https://ipfs.eth.aragon.network/ipfs/QmTCYzgvrjtV4ETkhM3ZNgrVYNi2roXhNxCRmwsePNqL1B/index.html/#/home```

### Considerations

Both of these features could lead into security problems. These were not addressed nor analysed, in this research, basic practices like sanitization could prevent things like XSS attack vectors

### Demo

#### A basic example app using react-router to handle the path and routes

[aragon-deeplink-example](https://github.com/mateotomasgomez/aragon-deeplink-example)

- Clone the demo repo and run the following commands `npx aragon devchain --reset`

`npm run start:http:template -- --client false`

- Take note of the DAO address

- Now on `https://github.com/ottodevs/aragon/tree/deeplinking`

- Run `npm run start:local`

- Open browser at: `http://localhost:3000/#/DAOADDRESS` , and click "Example" app
